### PR TITLE
Implement not default schema

### DIFF
--- a/.ipynb_checkpoints/requirements-checkpoint.txt
+++ b/.ipynb_checkpoints/requirements-checkpoint.txt
@@ -1,0 +1,2 @@
+pandas>=0.24.0
+SQLAlchemy>=1.3

--- a/pandabase/helpers.py
+++ b/pandabase/helpers.py
@@ -168,10 +168,14 @@ def get_column_dtype(column, pd_or_sqla, index=False):
         raise ValueError(f'Select pd_or_sqla must equal either "pd" or "sqla"')
 
 
-def has_table(con, table_name):
-    """return true of a table exactly named table_name exists in con"""
+def has_table(con, table_name, schema = None):
+    """returns True of a table exactly named table_name exists in con"""
     engine = engine_builder(con)
-    return engine.run_callable(engine.dialect.has_table, table_name)
+    
+    if schema is not None:
+        return engine.run_callable(engine.dialect.has_table, table_name, schema = schema)
+    else:
+        return engine.run_callable(engine.dialect.has_table, table_name)
 
 
 def clean_name(name):
@@ -184,7 +188,25 @@ def clean_name(name):
 
 
 def make_clean_columns_dict(df: pd.DataFrame, autoindex=False):
-    """Take a DataFrame and use_index, return a dictionary {name: {Column info}} (including index or not)"""
+    """Take a DataFrame and use_index, return a dictionary {name: {Column info}} (including index or not)
+    
+    
+    Example:
+        >>> import pandas as pd
+        >>> data = {'full_name':['John Doe'],
+        ...         'number_of_pets':[3],
+        ...         'likes_bananas':[True], 
+        ...         'dob':[pd.Timestamp('1990-01-01')]}
+        >>> 
+        >>> df = pd.DataFrame(data).rename_axis('id', axis = 'index')
+        >>> make_clean_columns_dict(df)
+        {'id': {'dtype': sqlalchemy.sql.sqltypes.Integer, 'pk': True},
+         'full_name': {'dtype': sqlalchemy.sql.sqltypes.String, 'pk': False},
+         'number_of_pets': {'dtype': sqlalchemy.sql.sqltypes.Integer, 'pk': False},
+         'likes_bananas': {'dtype': sqlalchemy.sql.sqltypes.Boolean, 'pk': False},
+         'dob': {'dtype': TIMESTAMP(timezone=True), 'pk': False}}
+    
+    """
     columns = {}
     df.columns = [clean_name(col) for col in df.columns]
 

--- a/pandabase/helpers.py
+++ b/pandabase/helpers.py
@@ -169,7 +169,7 @@ def get_column_dtype(column, pd_or_sqla, index=False):
 
 
 def has_table(con, table_name, schema = None):
-    """returns True of a table exactly named table_name exists in con"""
+    """returns True if a table exactly named table_name exists in con"""
     engine = engine_builder(con)
     
     if schema is not None:

--- a/pandabase/pandabase.py
+++ b/pandabase/pandabase.py
@@ -308,6 +308,7 @@ def read_sql(table_name: str,
         con:
         lowest: inclusive
         highest: inclusive
+        schema: Specify the schema (if database flavor supports this). If None, use default schema.
 
     Returns:
         DataFrame of selected data with table.primary_key as index


### PR DESCRIPTION
Hello,

I needed to work with other schemas than "public" in PostGres so I implemented non default schema handling.
I also fixed some typos, fixed a **bug with pd.NaT** (NULL representation for datetimes in pandas) and commented a few things. I suppose the bug with pd.NaT belongs in another branch and PR but it is quite late and I got lazy 🐌 . If you want I can do that when I have some time.

There are just a few things I'd like to point out/ask:
1. Would you mind explaining what this asterisk does? Is it for additional positional arguments (like *args)? And which of them exactly then?

```python
pandabase.to_sql(
    df: pandas.core.frame.DataFrame,
    *, # what is this asterisk ????
    table_name: str,
    con: str,
    auto_index=False,
    how='create_only',
    add_new_columns=False,
    schema: str = None,
)
```
2. I ran the existing tests but did not write tests using the schema argument (I just tested all functions on my own with a schema because I'm not sure how to use pytest). Is this what I am supposed to see?

![pandabase_test](https://user-images.githubusercontent.com/40694343/69485263-4b756480-0e3d-11ea-9286-4e269a44037b.png)

3. pd.NaT (NULL representation for datetimes) was causing crashes (it won't be recognized as a valid datetime when inserting into PG). Since it seems impossible to coerce pd.NaT to None in a Series (because I guess pandas reinferes the datatype after the operation and sets None back to pd.NaT) I did it at the row level. This solved the issue (I tested it and it seems to be me like a safe solution) however it may impact performance 👎 .

4. This is really brilliant work 🎉🎉🎉 ! Have you seen [PR 29636](https://github.com/pandas-dev/pandas/pull/29636) on pandas for adding upsert_delete and upsert_ignore to argument if_exists in to_sql? This looks very exciting! 
But there are 2 very nice features I like about pandabase that are still not adressed in this PR it seems:

* Imagine this scenario: you save a fully empty column (e.g. company name) upon saving a table. At the next data collection you end up having records later for this column. If you append with pd.DataFrame.to_sql it fails since empty columns/Series are of dtype float and you add text. But pandabase manages that by altering the column type in PG!
* Columns in data to append/upsert that are not in the PG table are automatically added